### PR TITLE
Fix outdated rtl8814au comment

### DIFF
--- a/code/base/hardware_radio.c
+++ b/code/base/hardware_radio.c
@@ -1519,7 +1519,8 @@ int hardware_radio_load_radio_modules(int iEchoToConsole)
       iCountLoaded++;
    }
 
-   if ( hardware_radio_has_rtl8814au_cards() ) // This function will be created in a later step
+   // Check for presence of RTL8814AU cards
+   if ( hardware_radio_has_rtl8814au_cards() )
    {
       if ( iEchoToConsole )
       {


### PR DESCRIPTION
## Summary
- remove stale note about rtl8814au function not existing

## Testing
- `make tests` *(fails: wiringPi.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68470a9bbd008330b500909a328c610b